### PR TITLE
feat: update to use fid over sid

### DIFF
--- a/AAUScheduleFinder.sh
+++ b/AAUScheduleFinder.sh
@@ -1,42 +1,49 @@
-#####################################
-# Auther: Thomas Lundsgaard Hansen  #
-# Date: 19-01-2019                  #
-# Version: 1.0                      #
-# License: GPL V3, 29 June 2007     #
-#####################################
+#!/usr/bin/env bash
+# AAU Schedule Finder - Finds your schedule in AAU's CalMoodle database without knowing its ID
+# Copyright (C) 2019-2020 Thomas Lundsgaard Hansen
+# Copyright (C) 2024 github.com/soupglasses
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#!/bin/bash
 clear
 
-# Print a welcome
-printf "Velkommen til AAUScheduleFinder!\nEt simplet værktøj til at finde din nye semester kalender ved AAU\n"
+echo "Velkommen til AAUScheduleFinder!"
+echo "Et simplet værktøj til at finde din nye semester kalender ved AAU."
+read -p "Indtast navnet på dit semester: " search
 
+echo "Bæmerk: Hvis du ikke ved dit fid, kan du tage udgangspunkt i at foråret 2024"
+echo "starter cirka ved fid 3000, og der eksisterer cirka 450 kalendere mellem"
+echo "hvert semester."
+read -p "Indtast dit FID fra sidste semester for at gøre søgningen hurtigere: " index
 
-# Prompt for the name of the calendar
-printf "Indtast navnet på dit semester: "
-read search
-
-# Prompt for the last known calendar id to speedup the search 
-printf "Indtast dit id fra sidste semester for at gøre søgningen hurtigere: "
-read index
-
-# Alert the user that the search has started
 printf "\nSøgningen er nu igang, vi giver besked hvis vi finder noget!\n"
 
-pstr="[=======================================================================]"
+# One semester is roughly 400-500 calendars wide. Set our search window to be roughly 2 semesters
+# in size to be safe, so 1000 indexes.
+let max_index=$index+1000
+pstr="........................................................................."
 
-# For any id from the one specified by the user to max id 9999 do a wget on the calendar url and
-# grep for the calendar name. If found the user will be alerted.
-for i in `seq $index 9999`;
-do
-pd=$(( ($i - $index ) * 73 /( 9999 - $index ) ))
-printf "\r%3d.%1d%% %.${pd}s" $(( ($i - $index ) * 100 / ( 9999 - $index ) )) $(( (( $i - $index ) * 1000 / ( 9999 - $index )) % 10 )) $pstr
-if wget -qO- https://www.moodle.aau.dk/calmoodle/public/\?sid\=$i | grep -q "$search"; then
-    echo "\nVi fandt en kalender på https://www.moodle.aau.dk/calmoodle/public/?sid=$i der passer dine søgekriterier."
-    echo "Vi forsætter søgningen i det tilfælde, at der er flere kalendre der passer til dine søgekriterier"
-    notify-send AAUSchedulFinder "Kalender fundet!"
-fi
+for i in `seq $index $max_index`; do
+    pd=$(( ($i - $index ) * 73 /( $max_index - $index ) ))
+    printf "\r%3d.%1d%% %.${pd}s" $(( ($i - $index ) * 100 / ( $max_index - $index ) )) $(( (( $i - $index ) * 1000 / ( $max_index - $index )) % 10 )) $pstr
+    if wget -qO- https://www.moodle.aau.dk/local/planning/calmoodle.php\?fid\=$i | grep -q "$search"; then
+        printf "\nVi fandt en kalender på fid $i!\n"
+        echo " - Bekræft venligst, at dette er den korrekte kalender på: https://www.moodle.aau.dk/local/planning/calmoodle.php?fid=$i"
+        echo " - Derefter kan du tilføje den til din kalender med: https://www.moodle.aau.dk/local/planning/ical.php?fid=$i"
+        echo "Vi forsætter søgningen i det tilfælde, at der er flere kalendre der passer til dine søgekriterier..."
+        notify-send AAUSchedulFinder "Kalender fundet!"
+    fi
 done
 
-# Final message to the user
-echo "Søgning slut. Hvis vi fandt noget vil det stå ovenfor."
+printf "\nSøgning afsluttet ved fid $i. Hvis vi fandt noget vil det stå ovenfor.\n"


### PR DESCRIPTION
It seems that CalMoodle has changed its approach to how it indexes its schedules the last 3 years. This PR updates AAUScheduleFinder.sh to use the new `fid` over the previous `sid` to find relevant schedules.

What is left untested is if `sid`s are still utilized. However, i do not know how to test for this.

Example `fid`s are 3249 for SW2, and 2779 for SW1.

Open for suggestions/edits.